### PR TITLE
Set state of deployed app to restarted

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,5 +31,5 @@
   when: ansible_distribution == "Ubuntu"
 
 - name: "Enable application {{app.name}}"
-  service: name={{app_init_prefix}}{{app.name}} enabled=yes
+  service: name={{app_init_prefix}}{{app.name}} enabled=yes state=restarted
   sudo: yes


### PR DESCRIPTION
To make sure it is started on first deploy and restarted on further deploys
